### PR TITLE
handle arrays without errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ CsvWriteStream.prototype._compile = function(headers) {
   str += 'return '
 
   headers.forEach(function(prop, i) {
-    str += (i ? '+"'+sep+'"+' : '') + '(/['+sep+'\\r\\n"]/.test('+prop+') ? esc('+prop+') : '+prop+')'
+    str += (i ? '+"'+sep+'"+' : '') + '(/['+sep+'\\r\\n"]/.test('+prop+') ? esc('+prop+'+"") : '+prop+')'
   })
 
   str += '+'+JSON.stringify(this.newline)+'\n}'

--- a/test.js
+++ b/test.js
@@ -124,3 +124,16 @@ test('serialize falsy values', function (t) {
   writer.write([false,'false',0,null,undefined])
   writer.end()
 })
+
+test('handle objects and arrays', function (t) {
+  var writer = csv({sendHeaders: false})
+
+  writer.pipe(concat(function (data) {
+    t.equal(data, '1,"1,2,3",[object Object]\n')
+    t.end()
+  }))
+
+  writer.write({a: 1, b: [1,2,3], c: {d: 1}})
+  writer.end()
+
+})


### PR DESCRIPTION
Hey,

I just took some time to actually understand to how the module works...

And the problem I was having in #13 was quite simply due to arrays as values. What happened whas that the `'(/['+sep+'\\r\\n"]/.test('+prop+')` part always was true on the implicit to string conversion of array properties (since `[1,2].toString()` contains a comma :D). 

Just turning the property to a string solves it and doesn't seem to add time to the benchmark on my computer (`+""` seems to be faster the `.toString()`)

I also added a test for it. It would probably also be cool to add a `jsonMode`, which would actually stringify those array and object properties correctly.

Best,
Finn
