### PR TITLE
modify readme to make examples consistent with require statement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ var writer = csvWriter()
 example of auto headers:
 
 ```js
-var writer = csv()
+var writer = csvWriter()
 writer.pipe(fs.createWriteStream('out.csv'))
 writer.write({hello: "world", foo: "bar", baz: "taco"})
 writer.end()
@@ -46,7 +46,7 @@ writer.end()
 example of specifying headers:
 
 ```js
-var writer = csv({ headers: ["hello", "foo"]})
+var writer = csvWriter({ headers: ["hello", "foo"]})
 writer.pipe(fs.createWriteStream('out.csv'))
 writer.write(['world', 'bar'])
 writer.end()
@@ -57,7 +57,7 @@ writer.end()
 example of not sending headers:
 
 ```js
-var writer = csv({sendHeaders: false})
+var writer = csvWriter({sendHeaders: false})
 writer.pipe(fs.createWriteStream('out.csv'))
 writer.write({hello: "world", foo: "bar", baz: "taco"})
 writer.end()


### PR DESCRIPTION
Very minor point but in the documentation `csv-write-stream` is required as `var csvWriter = require('csv-write-stream')`.

The line `var writer = csv()` in examples would result in an error as `csv` would be undefined.