### PR TITLE
Specify resulting encoding as optional parameter

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -24,6 +24,10 @@ argparser.addArgument(['--headers'], {
   help: 'The list of headers to use. If omitted, the keys of the first row ' +
   'written to STDIN will be used',
 })
+argparser.addArgument(['--encoding'], {
+  help: "The encoding to use for the output. Defaults to 'UTF-8'.",
+  defaultValue: 'UTF-8'
+})
 argparser.addArgument(['--no-send-headers'], {
   action: 'storeFalse',
   help: "Don't print the header row.",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "argparse": "^1.0.7",
     "generate-object-property": "^1.0.0",
+    "legacy-encoding": "^3.0.0",
     "ndjson": "^1.3.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,8 @@ var writer = csvWriter()
   separator: ',',
   newline: '\n',
   headers: undefined,
-  sendHeaders: true
+  sendHeaders: true,
+  encoding: 'UTF-8'
 }
 ```
 
@@ -96,6 +97,8 @@ Optional arguments:
   --headers HEADERS [HEADERS ...]
                         The list of headers to use. If omitted, the keys of
                         the first row written to STDIN will be used
+  --encoding ENCODING   The encoding to use for the output. Defaults to
+                        'UTF-8'.
   --no-send-headers     Don't print the header row.
 ```
 


### PR DESCRIPTION
Add another option 'encoding' to specify the encoding of the resulting file.