### PR TITLE
Fix objectMode for Readable side

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var gen = require('generate-object-property')
 
 var CsvWriteStream = function(opts) {
   if (!opts) opts = {}
-  stream.Transform.call(this, {objectMode:true, highWaterMark:16})
+  stream.Transform.call(this, {readableObjectMode:false, writableObjectMode:true, encoding:'utf8'})
 
   this.sendHeaders = opts.sendHeaders !== false
   this.headers = opts.headers || null


### PR DESCRIPTION
Hi,

The fact that this stream is in `objectMode` on both sides doesn't seem to play well with stuff that require a "normal" stream to work (eg. hapi). I also removed the `highWatermark` as it allows node to have more sensible settings on both sides of the transform stream. The benchmark places this patch roughly in the same ballpark as the master, with or without the `highWatermark`.

Happy to work with you if you feel this needs additional tests, although existing tests feel like enough to prove it didn't break anything.