### PR TITLE
Configurable highWaterMark for Transform Stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,10 @@ var gen = require('generate-object-property')
 
 var CsvWriteStream = function(opts) {
   if (!opts) opts = {}
-  stream.Transform.call(this, {objectMode:true, highWaterMark:16})
+  stream.Transform.call(this, {
+    objectMode: true,
+    highWaterMark: opts.highWaterMark || 16
+  })
 
   this.sendHeaders = opts.sendHeaders !== false
   this.headers = opts.headers || null


### PR DESCRIPTION
I was running into the issue of a lot of back pressure being applied to previous streams as a result of the rest of the streams in the pipeline having a higher `highWaterMark` setting. By making this configurable based on the user's needs, the amount of back pressure can be controlled.

I know this repo has stagnated (possibly because it's considered "feature complete") but I think the default of 16 isn't suitable in cases where more control of the stream is needed. I'd love to see this merged into the parent repo.