### PR TITLE
Fix EPIPE error on destroyed stdout (CLI)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -37,3 +37,7 @@ process.stdin
   .pipe(ndj.parse())
   .pipe(csv(args))
   .pipe(process.stdout)
+  .on('error', err => {
+    if (err.code === 'EPIPE') return
+    throw err
+  })


### PR DESCRIPTION
Piping the output to a consumer that ends before reading all output (e.g. `head`) will result in an EPIPE error.

```sh
$ echo '{"a":1}' | csv-write | head -n1 
a
events.js:291
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at afterWriteDispatched (internal/stream_base_commons.js:156:25)
    at writeGeneric (internal/stream_base_commons.js:147:3)
    at Socket._writeGeneric (net.js:785:11)
    at Socket._write (net.js:797:8)
    at writeOrBuffer (_stream_writable.js:352:12)
    at Socket.Writable.write (_stream_writable.js:303:10)
    at CsvWriteStream.ondata (_stream_readable.js:713:22)
    at CsvWriteStream.emit (events.js:314:20)
    at addChunk (_stream_readable.js:303:12)
    at readableAddChunk (_stream_readable.js:279:9)
Emitted 'error' event on Socket instance at:
    at Socket.onerror (_stream_readable.js:754:14)
    at Socket.emit (events.js:314:20)
    at emitErrorNT (internal/streams/destroy.js:100:8)
    at emitErrorCloseNT (internal/streams/destroy.js:68:3)
    at processTicksAndRejections (internal/process/task_queues.js:80:21) {
  errno: -32,
  code: 'EPIPE',
  syscall: 'write'
}
```